### PR TITLE
Enable enable-reflector flag in avahi

### DIFF
--- a/src/etc/avahi/avahi-daemon.conf
+++ b/src/etc/avahi/avahi-daemon.conf
@@ -1,0 +1,71 @@
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+# See avahi-daemon.conf(5) for more information on this configuration
+# file!
+
+[server]
+#host-name=foo
+#domain-name=local
+#browse-domains=0pointer.de, zeroconf.org
+use-ipv4=yes
+use-ipv6=yes
+#allow-interfaces=eth0
+#deny-interfaces=eth1
+#check-response-ttl=no
+#use-iff-running=no
+#enable-dbus=yes
+#disallow-other-stacks=no
+#allow-point-to-point=no
+#cache-entries-max=4096
+#clients-max=4096
+#objects-per-client-max=1024
+#entries-per-entry-group-max=32
+ratelimit-interval-usec=1000000
+ratelimit-burst=1000
+
+[wide-area]
+enable-wide-area=yes
+
+[publish]
+#disable-publishing=no
+#disable-user-service-publishing=no
+#add-service-cookie=no
+#publish-addresses=yes
+publish-hinfo=no
+publish-workstation=no
+#publish-domain=yes
+#publish-dns-servers=192.168.50.1, 192.168.50.2
+#publish-resolv-conf-dns-servers=yes
+#publish-aaaa-on-ipv4=yes
+#publish-a-on-ipv6=no
+
+[reflector]
+# Enabled reflector to spread mdns requests across all local network interfaces
+# so mdns resolution works across multiple hops, but enabling this on all nodes
+# may cause nodes to play ping pong with mdns packets 
+enable-reflector=yes
+#reflect-ipv=no
+
+[rlimits]
+#rlimit-as=
+rlimit-core=0
+rlimit-data=4194304
+rlimit-fsize=0
+rlimit-nofile=768
+rlimit-stack=4194304
+rlimit-nproc=3


### PR DESCRIPTION
In the [three-node mesh set up](https://github.com/benhylau/mesh-workshop#mesh-three-nodes-using-cjdns-and-yggdrasil), putting this on the middle relaying node actually allows the two edge nodes to resolve each other's mDNS addresses.

While convenient, I do not plan to merge this because:

* It gives a false sense that this is how mDNS works
* Putting this on all the nodes may cause a packet storm 

Build from this branch if you want to tinker with this.