### PR TITLE
Raspberry pi 2 ath9k removal

### DIFF
--- a/src/sh/02-raspberrypi2.sh
+++ b/src/sh/02-raspberrypi2.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [[ "$(cat /sys/firmware/devicetree/base/model | awk '{print $3}')" == "2" ]]; then
+    sed -i "s/ath9k_htc //" /etc/systemd/network/85-wlan-mesh.link
+    sed -i "s/ath9k_htc //" /etc/systemd/network/85-wlan-mesh.network
+fi

--- a/src/sh/02-raspberrypi2.sh
+++ b/src/sh/02-raspberrypi2.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [[ "$(cat /sys/firmware/devicetree/base/model | awk '{print $3}')" == "2" ]]; then
     sed -i "s/ath9k_htc //" /etc/systemd/network/85-wlan-mesh.link
     sed -i "s/ath9k_htc //" /etc/systemd/network/85-wlan-mesh.network


### PR DESCRIPTION
Remove the Ath9k driver from raspberry pi 2 from possible mesh drivers. This allows it to become an Access Point instead