### PR TITLE
Led

### DIFF
--- a/src/sh/01-led-light.sh
+++ b/src/sh/01-led-light.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+echo LED Indicator
+mount >> /var/log/test1
+mount -t sysfs sysfs /sys
+ls /sys/class  >>/var/log/test1
+ls /sys/class/led  >>/var/log/test1
+echo heartbeat > /sys/class/leds/led1/trigger 
+echo none > /sys/class/leds/led0/trigger
+echo 0 > /sys/class/leds/led0/brightness
+echo '#!/bin/sh' > /etc/rc.local
+echo "echo 1 > /sys/class/leds/led1/brightness" >> /etc/rc.local
+echo "echo 1 > /sys/class/leds/led0/brightness" >> /etc/rc.local
+echo "exit 0" >> /etc/rc.local
+chmod +x /etc/rc.local
+

--- a/src/sh/01-led-light.sh
+++ b/src/sh/01-led-light.sh
@@ -11,9 +11,7 @@ echo 1 > /sys/class/leds/led1/brightness
 echo 1 > /sys/class/leds/led0/brightness
 exit 0 
 EOF
-
 chmod +x /usr/local/bin/bootedled
-
 
 cat <<"EOF"> /lib/systemd/system/bootedled.service
 [Unit]
@@ -30,6 +28,6 @@ RestartSec=10s
 [Install]
 WantedBy=multi-user.target
 EOF
- 
+
 systemctl daemon-reload
 systemctl enable bootedled.service


### PR DESCRIPTION
Added boot-status light for the raspberry pi 2 and 3
Issue #7 
RED + GREEN (green is when its readings SD card during boot) loading the kernel and ram disk
RED - Booting the ram disk (no SD activity so it goes green)
Blinking Red - Booting os  (Green SD activity now disabled triggers as 01 conf.d script)
Blinking Red+ Green - Os fully booted